### PR TITLE
Add GET /api/v1/goals endpoint and GoalResponse DTO

### DIFF
--- a/be/src/main/java/com/be/goal/controller/GoalController.java
+++ b/be/src/main/java/com/be/goal/controller/GoalController.java
@@ -3,8 +3,9 @@ package com.be.goal.controller;
 import com.be.global.response.CommonResponse;
 import com.be.global.response.IdResponse;
 import com.be.global.security.UserPrincipal;
-import com.be.goal.service.GoalService;
 import com.be.goal.dto.GoalCreateRequest;
+import com.be.goal.dto.GoalResponse;
+import com.be.goal.service.GoalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,6 +20,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/goals")
 public class GoalController {
     private final GoalService goalService;
+
+
+
+    @Operation(summary = "목표 다건 조회", description = "로그인 사용자의 목표 목록을 조회합니다.")
+    @GetMapping("")
+    public CommonResponse<java.util.List<GoalResponse>> getGoals(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal.getUserId();
+        return CommonResponse.success(goalService.getGoals(userId));
+    }
 
     @Operation(summary = "목표 생성", description = "로그인 사용자의 목표를 생성합니다.")
     @PostMapping("")

--- a/be/src/main/java/com/be/goal/dto/GoalResponse.java
+++ b/be/src/main/java/com/be/goal/dto/GoalResponse.java
@@ -1,0 +1,32 @@
+package com.be.goal.dto;
+
+import com.be.goal.domain.Goal;
+import com.be.goal.domain.GoalPriority;
+import com.be.goal.domain.GoalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class GoalResponse {
+
+    private Long goalId;
+    private String title;
+    private String description;
+    private GoalPriority priority;
+    private GoalStatus status;
+    private LocalDate targetDate;
+
+    public static GoalResponse from(Goal goal) {
+        return GoalResponse.builder()
+                .goalId(goal.getId())
+                .title(goal.getTitle())
+                .description(goal.getDescription())
+                .priority(goal.getPriority())
+                .status(goal.getStatus())
+                .targetDate(goal.getTargetDate())
+                .build();
+    }
+}

--- a/be/src/main/java/com/be/goal/repository/GoalRepository.java
+++ b/be/src/main/java/com/be/goal/repository/GoalRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface GoalRepository extends JpaRepository<Goal, Long> {
-    List<Goal> findByUserId(Long userId);
+    List<Goal> findByUserIdOrderByIdDesc(Long userId);
 }

--- a/be/src/main/java/com/be/goal/service/GoalService.java
+++ b/be/src/main/java/com/be/goal/service/GoalService.java
@@ -4,6 +4,7 @@ import com.be.global.exception.BusinessException;
 import com.be.global.exception.ErrorCode;
 import com.be.goal.domain.Goal;
 import com.be.goal.dto.GoalCreateRequest;
+import com.be.goal.dto.GoalResponse;
 import com.be.goal.repository.GoalRepository;
 import com.be.user.domain.User;
 import com.be.user.repository.UserRepository;
@@ -30,6 +31,17 @@ public class GoalService {
         );
 
         return goalRepository.save(goal).getId();
+    }
+
+
+
+    @Transactional(readOnly = true)
+    public java.util.List<GoalResponse> getGoals(Long userId) {
+        getUser(userId);
+        return goalRepository.findByUserIdOrderByIdDesc(userId)
+                .stream()
+                .map(GoalResponse::from)
+                .toList();
     }
 
     private User getUser(Long userId) {


### PR DESCRIPTION
### Motivation
- Provide an endpoint to retrieve the logged-in user's goals as a list for the frontend to display.
- Introduce a response DTO to decouple API shape from the domain entity and control returned fields.
- Return goals in descending order (newest first) to surface recent entries.

### Description
- Added `GoalResponse` DTO with a `from(Goal)` mapper to shape API responses.
- Implemented `GET /api/v1/goals` in `GoalController` returning `CommonResponse<List<GoalResponse>>` using the authenticated `UserPrincipal`.
- Added `getGoals` service method in `GoalService` annotated with `@Transactional(readOnly = true)` to fetch and map goals.
- Updated `GoalRepository` query method to `findByUserIdOrderByIdDesc` to return goals ordered by id descending.

### Testing
- Ran the project's automated test suite with `./gradlew test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c55f0c60832ca32f5dfc50418cb3)